### PR TITLE
almost forgot to register config RPCs with Server in previous check-i…

### DIFF
--- a/doc/issue_115_configrpc/README.md
+++ b/doc/issue_115_configrpc/README.md
@@ -1,6 +1,6 @@
 # Development Notes for Issue #115 – Config RPC Exposure
 
-This folder tracks development work related to [Bitcoin Knots Issue #115](https://github.com/bitcoinknots/bitcoin/issues/115), which proposes the creation of new RPC endpoints to expose configuration values from GUI-only or runtime policy settings for use in headless environments, dashboards and website integrations.
+This folder tracks development work related to [Bitcoin Knots Issue #115](https://github.com/bitcoinknots/bitcoin/issues/115), which proposes the creation of new RPC endpoints to expose configuration values from GUI-only or runtime policy settings for use in headless environments, dashboards, website integrations and network sharing of settings via RPC.
 
 ---
 
@@ -10,24 +10,57 @@ Currently, several node configuration and policy settings are only viewable in t
 
 ---
 
-## 🎯 FOSS Community-Guidance Notes (Summarized from Discord & Issue #115 Discussion)
+## 🧭 Big Picture – One Flexible Reader/Writer Pair
 
-This initiative aims to create **four RPCs** that satisfy three key design goals:
+This effort has consolidated around a single flexible pair of RPCs that support both local configuration updates and remote configuration fetching.
 
-1. **Expose GUI-only settings via RPC** (for headless usability)
-2. **Support runtime updates to those settings via RPC**
-3. **Enable safe export/import (i.e. sharing) of complete configuration bundles**
+### Unified Pair: Runtime Get/Set (Session-Scoped + Optional Persist)
+
+- **`getconfigvalues`** (Previously `getconfiginfo`)
+  - Purpose: Fetch current runtime config values.
+  - Input: Optional list of config keys (defaults to all). Optional `targetnode` argument (default: self).
+  - Output: Flat key-value JSON object.
+  - Notes:
+    - Output grouping for UX purposes is **client-side only** to avoid long-term coupling.
+    - Category-based display grouping (e.g., mempool, privacy) should not be embedded in core responses.
+  - Potential Enhancements:
+    1. Add `targetnode` to pull config from another node.
+    2. Add subset fetch via `keys` array (e.g., `["blockmintxfee"]`, `[*]`= all). 
+    3. Add `persist=true` option to write fetched config to `bitcoin_rw.conf`.
+    4. (TBD) Allow fetch-and-apply combo, e.g., for copying trusted configs.
+
+- **`setconfigvalues`** (In Progress)
+  - Purpose: Set one or more config values at runtime.
+  - Input: JSON object matching config schema.
+  - Output: Array of per-key result objects:
+    ```json
+    [
+      {
+        "key": "string (keyname)",
+        "applied": true|false,
+        "persisted": true|false,
+        "errors": [
+            NONE,
+            KEY_NOT_FOUND,
+            FILE_ERROR,
+            NODE_NOT_FOUND,...
+        ]
+      }
+    ]
+    ```
+    This structure is designed to allow batched feedback for batched input, even when some keys succeed and others fail.
+  
+  - Potential Enhancements:
+    - Accept `persist=true` to immediately write all accepted settings to `bitcoin_rw.conf`.
 
 ---
 
 ## 📍 RPC Roadmap
 
-| RPC Name              | Purpose                                         | Status                                   |
-|-----------------------|--------------------------------------------------|------------------------------------------|
-| `getconfiginfo`       | Exposes current node config values              | ✅ Implemented locally, On-Fork as feature/getconfiginfo |
-| `setconfigvalue`      | Enables runtime updates to specific settings    | ⏳ In progress as feature/setconfiginfo   |
-| `exportconfigbundle`  | Outputs all user-modifiable config values       | ⏳ Planned                                |
-| `importconfigbundle`  | Applies config bundle with safe validation      | ⏳ Planned                                |
+| RPC Name          | Purpose                                         | Status                                   |
+|-------------------|--------------------------------------------------|------------------------------------------|
+| `getconfigvalues` | Exposes current node config values              | ✅ Implemented locally                    |
+| `setconfigvalues` | Enables runtime updates to specific settings    | ⏳ In progress                            |
 
 All implementations return structured JSON objects for integration with external tools.
 
@@ -35,19 +68,17 @@ All implementations return structured JSON objects for integration with external
 
 ## 📦 Current Status as of Commit-date 06/04/2025
 
-- 🔨 `getconfiginfo` implemented
+- 🔨 `getconfigvalues` implemented
 - ✅ Compiles cleanly, visible under RPC `help`
-- ✅ Returns datacarrier, fees, and blocks-only status with expected formatting conventions
-- ✅ Offers optional UX-style grouping or flat key-value map (default)
-- 🔁 Prepping next RPC: `setconfigvalue`
+- ✅ Returns expected config items as flat JSON object
+- ✅ Accepts optional UX-style grouping (legacy)
+- 🔁 Prepping next RPC: `setconfigvalues`
 
 ---
 
-## 🧱 Proposed Config Schema (get/export/import)
+## 🧱 Proposed Config Schema
 
-We propose a flat key-value map format mirroring `bitcoin.conf` layout, represented in JSON Schema form, which should ease potential
-future movement between file-based configuration (i.e. bitcoin_rw.conf) and dynamic run-time operations, executed locally or via 
-network resources:
+We propose a flat key-value map format mirroring `bitcoin.conf` layout, represented in JSON Schema form:
 
 ```json
 {
@@ -72,19 +103,19 @@ network resources:
 }
 ```
 
-This schema is suitable for programmatic editing, syncing, UI input, and automation flows.
+This schema is suitable for UI inputs, file-based persistence (`bitcoin_rw.conf`), scripting, and automation flows.
 
 ---
 
 ## 🔁 Runtime Change Semantics
 
-Settings fall into different categories of runtime mutability when considered under the following strategy or approach:
+Settings fall into different categories of runtime mutability under the following approach:
 
-- We propose **No eviction or disconnection** of existing peers or mempool contents when relevant settings change at runtime.
-- Changes need **only apply to new inbound data** (mempool entries, connections, block creation) which keeps this work simple, useful, non-aggressive.
-- Some settings are still not amenable to runtime mutation based on the nature of what they control.
+- **No eviction or disconnection** of current txns or peers.
+- **Only new data** (connections, transactions, blocks) is affected.
+- **Non-runtime modifiable settings** are clearly identified.
 
-We suggest the following table, listing each config key considered under this change, its runtime mutability status, and categorization notes.
+### Runtime Mutability Table
 
 | Setting              | Mutable | Notes                                                         | Affects            |
 |----------------------|---------|----------------------------------------------------------------|--------------------|
@@ -97,7 +128,7 @@ We suggest the following table, listing each config key considered under this ch
 | blockmaxsize         | ✅ Yes  | Used in next block construction only                           | Mining             |
 | blockmaxweight       | ✅ Yes  | Same as above                                                  | Mining             |
 | blockmintxfee        | ✅ Yes  | Used in mining template generation                             | Mining             |
-| blockprioritysize    | ✅ Yes  | Mining block template override                                | Mining             |
+| blockprioritysize    | ✅ Yes  | Mining block template override                                 | Mining             |
 | whitelistforcerelay  | ✅ Yes  | Affects newly arriving peers                                   | Network/Peers      |
 | whitelistrelay       | ✅ Yes  | Affects relay of txns from whitelisted peers                   | Network/Peers      |
 | walletrbf            | ❌ No   | Requires wallet reload                                         | Wallet             |
@@ -108,29 +139,6 @@ We suggest the following table, listing each config key considered under this ch
 | listen               | ❌ No   | Startup-level option                                           | Network/Startup    |
 | peerbloomfilters     | ❌ No   | Affects service flags, requires restart                       | Network/Service    |
 | blockfilterindex     | ❌ No   | Requires indexing and restart                                 | Indexing/Storage   |
-
----
-
-## 📤 Planned Return Format for `setconfigvalue`
-
-Because setconfigvalue will take any conformant JSON Bitcoin Config Key-Value Map as input, it will output a matching map of *application result objects*
-for each included item (some may succeed, others fail etc).
-
-Here are proposed examples of individual kinds of results: 
-
-```json
-{
-  "key": "blockmintxfee",
-  "applied": true,
-  "message": "Updated successfully. Will persist for this session and apply to new transactions or blocks. Use export to transfer to persistent file."
-}
-```
-
-Other classes of behavior include:
-
-- 🧠 Mempool-only: applies only to new mempool entries.
-- 🌐 Peer-related: applies only to newly connected peers.
-- ⚠️ Non-modifiable: clear error and guidance to use `bitcoin.conf` or `bitcoin_rw.conf`.
 
 ---
 
@@ -145,9 +153,9 @@ Other classes of behavior include:
 
 ## 🔭 Future Network Interop (Optional Direction)
 
-A future direction is syncing config schemas (in whole or part) across federated dashboards, trusted peers, or validator sets.
+Potential future goal: support trusted config pulls from canonical sources (e.g., pools, federations, NGOs).
 
-Example: Pool templates, canary configurations, policy alignment, served from community servers for download and application at runtime.
+- Example: `getconfigvalues targetnode=template.ocean.coop persist=true`
 
 ---
 
@@ -160,7 +168,7 @@ KNOTS-DEV/
 │       └── README.md      ← You are here
 ├── src/
 │   └── rpc/
-│       └── config.cpp     ← New RPC implementations
+│       └── config.cpp     ← New RPC implementation
 │       └── register.h     ← RPC registration hook
 └── src/Makefile.am        ← Build integration
 ```

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -340,6 +340,8 @@ CRPCTable::CRPCTable()
     for (const auto& c : vRPCCommands) {
         appendCommand(c.name, &c);
     }
+    RegisterConfigRPCCommands(*this);
+
 }
 
 void CRPCTable::appendCommand(const std::string& name, const CRPCCommand* pcmd)


### PR DESCRIPTION
…n, also major updates to roadmap to consolidate RPCs into a single get/set pair with configurability handling local vs network, session vs persisted optionality

<!--
*** Please remove the following help text before submitting: ***

Before opening a pull request to Bitcoin Knots, please first consider if it
is appropriate for Bitcoin Core and, if so, rebase it and [open a pull request](https://github.com/bitcoin/bitcoin/compare)
there first! Bitcoin Core has a strict and slow review process, but since
Knots is more relaxed, feel free to request a merge of your Core PR into
Knots even while it's waiting on Core.

-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Knots user experience or Bitcoin Knots developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are typically welcome.
* Refactoring changes are never accepted in Knots, and must be performed in
  Bitcoin Core.
-->
